### PR TITLE
Fix for Init failure due to missing trailing slash on tessdata path

### DIFF
--- a/api/TesseractInitializer.cpp
+++ b/api/TesseractInitializer.cpp
@@ -108,6 +108,12 @@ bool TesseractProcessor::Init(String* dataPath, String* lang, int ocrEngineMode)
 {
 	bool bSucced = false;
 
+	// Append required trailing slash if missing
+	if(!dataPath->EndsWith("\\"))
+	{
+		dataPath = System::String::Concat(dataPath, "\\");
+	}
+
 	_dataPath = dataPath;
 	_lang = lang;
 	_ocrEngineMode = ocrEngineMode;

--- a/api/TesseractInitializer.cpp
+++ b/api/TesseractInitializer.cpp
@@ -109,9 +109,10 @@ bool TesseractProcessor::Init(String* dataPath, String* lang, int ocrEngineMode)
 	bool bSucced = false;
 
 	// Append required trailing slash if missing
-	if(!dataPath->EndsWith("\\"))
+	String* separator = (System::IO::Path::DirectorySeparatorChar).ToString();
+	if(!dataPath->EndsWith(separator))
 	{
-		dataPath = System::String::Concat(dataPath, "\\");
+		dataPath = System::String::Concat(dataPath, separator);
 	}
 
 	_dataPath = dataPath;


### PR DESCRIPTION
Loving this library, thanks! I had it up and running within a short period of time but I spun for a few minutes with unexpected failures during the Init call. I'm not sure if this fix is really necessary or the best approach but it seemed better to add the slash if missing rather than fail the call.
