### PR TITLE
Added a function to retrieve the rotation of the image (after it's been analyzed)

### DIFF
--- a/api/PageLayoutAnalyzer.cpp
+++ b/api/PageLayoutAnalyzer.cpp
@@ -81,6 +81,19 @@ DocumentLayout* TesseractProcessor::AnalyseLayout(System::Drawing::Image* image)
 	}
 }
 
+int TesseractProcessor::GetRotation()
+{
+	int blockrotation = 0;
+	int* blockpointer = &blockrotation;
+
+	bool dummy = true;
+	bool* dummypointer = &dummy;
+
+	this->EngineAPI->GetBlockTextOrientations(&blockpointer, &dummypointer);
+
+	return (*blockpointer) * 90;
+}
+
 DocumentLayout* TesseractProcessor::AnalyseLayoutBinaryImage(
 	unsigned char* binData, int width, int height)
 {

--- a/api/TesseractEngineWrapper.h
+++ b/api/TesseractEngineWrapper.h
@@ -125,6 +125,7 @@ public:
 	bool GetDoubleVariable(System::String* name, double __gc* value);
 	System::String* GetStringVariable(System::String* name);
 
+
 	bool SetVariable(System::String* nam, System::String* value);
 
 	void DisableThresholder();
@@ -163,7 +164,7 @@ public:
 	//
 	String* RecognizeGreyImage(unsigned short* greyData, int width, int height);
 
-
+	
 
 
 private:
@@ -191,7 +192,8 @@ public:
 	DocumentLayout* AnalyseLayoutBinaryImage(unsigned char* binData, int width, int height);
 	DocumentLayout* AnalyseLayoutGreyImage(unsigned char* greyData, int width, int height);
 	DocumentLayout* AnalyseLayoutGreyImage(unsigned short* greyData, int width, int height);
-
+	
+	int GetRotation();
 
 
 


### PR DESCRIPTION
This is especially useful to me, since I need to overlay the text contents on the original image.  All the coordinates are applied to an image that has already been rotated.  Thus, I need this value so that I can adjust the image accordingly to match the coordinates that Tesseract returns.
